### PR TITLE
Add day-night cycle and seasonal mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Simple console fishing game in Python.
 - Multiple fishing zones with different fish types
 - Dynamic quest system that keeps up to 20 quests active
 - Shop and inventory management
+- Day/night cycle with seasons affecting fish availability
 
 Run the game with:
 


### PR DESCRIPTION
## Summary
- Track days and seasons with helper functions and emoji mapping.
- Display time of day, day count, and season in main menu.
- Filter fish availability based on time of day and season.

## Testing
- `python -m py_compile fishing.py`
- `python - <<'PY'
from fishing import Game
line1 = f"hour {g.current_hour} tod {g.get_time_of_day()}"
line2 = f"day {g.current_day} season {g.get_current_season()}"
print(line1)
print(line2)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6892dfb5816c8331abb49f3c90d3f7e8