### PR TITLE
Clamp quest amounts by rarity

### DIFF
--- a/fishing.py
+++ b/fishing.py
@@ -338,6 +338,14 @@ class QuestManager:
         else:
             rarity = random.choice(list({f["rarity"] for f in fish_list}))
             target_fish = None
+
+        max_amount = 15
+        if rarity == "Legendary":
+            max_amount = 5
+        elif rarity == "Boss":
+            max_amount = 1
+        amount = min(amount, max_amount)
+
         base_values = {
             "Common": 10,
             "Uncommon": 20,


### PR DESCRIPTION
## Summary
- cap quest fish amounts to 15 by default
- restrict Legendary quests to at most 5 fish
- limit Boss quests to 1 fish

## Testing
- `python -m py_compile fishing.py`


------
https://chatgpt.com/codex/tasks/task_e_68955547d2c08331b7a113d7c0e787b9